### PR TITLE
move eboot_address to module.h

### DIFF
--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -11,7 +11,6 @@
 #include "core/loader/dwarf.h"
 #include "core/memory.h"
 #include "core/module.h"
-#include "qt_gui/cheats_patches.h"
 
 namespace Core {
 
@@ -19,6 +18,8 @@ using EntryFunc = PS4_SYSV_ABI int (*)(size_t args, const void* argp, void* para
 
 static u64 LoadOffset = CODE_BASE_OFFSET;
 static constexpr u64 CODE_BASE_INCR = 0x010000000u;
+
+uintptr_t g_eboot_address;
 
 static u64 GetAlignedSize(const elf_program_header& phdr) {
     return (phdr.p_align != 0 ? (phdr.p_memsz + (phdr.p_align - 1)) & ~(phdr.p_align - 1)
@@ -91,9 +92,9 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     LoadOffset += CODE_BASE_INCR * (1 + aligned_base_size / CODE_BASE_INCR);
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));
 
-    if (cheats_eboot_address == 0) {
+    if (g_eboot_address == 0) {
         if (name == "eboot") {
-            cheats_eboot_address = base_virtual_addr;
+            g_eboot_address = base_virtual_addr;
         }
     }
 

--- a/src/core/module.h
+++ b/src/core/module.h
@@ -243,4 +243,6 @@ public:
     std::vector<u8> rela_bits;
 };
 
+extern uintptr_t g_eboot_address;
+
 } // namespace Core

--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -21,8 +21,7 @@
 #include <common/logging/log.h>
 #include "cheats_patches.h"
 #include "common/path_util.h"
-
-uintptr_t cheats_eboot_address = 0;
+#include "core/module.h"
 
 CheatsPatches::CheatsPatches(const QString& gameName, const QString& gameSerial,
                              const QString& gameVersion, const QString& gameSize,
@@ -268,7 +267,7 @@ void CheatsPatches::applyCheat(const QString& modName, bool enabled) {
     if (!m_cheats.contains(modName))
         return;
 
-    if (cheats_eboot_address == 0) {
+    if (Core::g_eboot_address == 0) {
         QMessageBox::warning(this, "Cheats not found",
                              "Can't apply mod until a game has been started.");
         return;
@@ -287,7 +286,7 @@ void CheatsPatches::applyCheat(const QString& modName, bool enabled) {
 
         // Send a request to modify the process memory.
         void* cheatAddress =
-            reinterpret_cast<void*>(cheats_eboot_address + std::stoi(offsetStr, 0, 16));
+            reinterpret_cast<void*>(Core::g_eboot_address + std::stoi(offsetStr, 0, 16));
 
         std::vector<unsigned char> bytePatch;
 

--- a/src/qt_gui/cheats_patches.h
+++ b/src/qt_gui/cheats_patches.h
@@ -16,8 +16,6 @@
 #include <QVector>
 #include <QWidget>
 
-extern uintptr_t cheats_eboot_address;
-
 class CheatsPatches : public QWidget {
     Q_OBJECT
 


### PR DESCRIPTION
fixes the non-qt builds and makes more sense to be there anyway