### PR TITLE
Initial Patch Implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,8 @@ set(COMMON src/common/logging/backend.cpp
            src/common/enum.h
            src/common/io_file.cpp
            src/common/io_file.h
+           src/common/memory_patcher.cpp
+           src/common/memory_patcher.h
            src/common/error.cpp
            src/common/error.h
            src/common/scope_exit.h

--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -13,16 +13,17 @@ void AddPatchToQueue(patchInfo patchToAdd) {
 
 void ApplyPendingPatches() {
 
-	for (size_t i = 0; i < pending_patches.size(); ++i) {
+for (size_t i = 0; i < pending_patches.size(); ++i) {
         patchInfo currentPatch = pending_patches[i];
         PatchMemory(currentPatch.modNameStr, currentPatch.offsetStr, currentPatch.valueStr,
-            currentPatch.isOffset);
+                    currentPatch.isOffset);
     }
 
     pending_patches.clear();
 }
 
-void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr, bool isOffset) {
+void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr,
+                 bool isOffset) {
     // Send a request to modify the process memory.
     void* cheatAddress = nullptr;
 
@@ -44,7 +45,7 @@ void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valu
     std::memcpy(cheatAddress, bytePatch.data(), bytePatch.size());
 
     LOG_INFO(Loader, "Applied patch:{}, Offset:{}, Value:{}", modNameStr, (uintptr_t)cheatAddress,
-        valueStr);
+             valueStr);
 }
 
 } // namespace MemoryPatcher

--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -1,0 +1,44 @@
+#include "memory_patcher.h"
+#include "common/logging/log.h"
+
+namespace MemoryPatcher 
+{
+
+uintptr_t g_eboot_address;
+
+std::vector<patchInfo> pending_patches;
+
+void AddPatchToQueue(patchInfo patchToAdd) {
+    pending_patches.push_back(patchToAdd);
+}
+
+void ApplyPendingPatches() {
+
+	for (size_t i = 0; i < pending_patches.size(); ++i) {
+        patchInfo currentPatch = pending_patches[i];
+        LOG_INFO(Loader, "loading patch {}", i);
+        PatchMemory(currentPatch.modNameStr, currentPatch.offsetStr, currentPatch.valueStr);
+    }
+
+    pending_patches.clear();
+}
+
+void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr) {
+    // Send a request to modify the process memory.
+    void* cheatAddress =
+        reinterpret_cast<void*>(g_eboot_address + std::stoi(offsetStr, 0, 16));
+
+    std::vector<unsigned char> bytePatch;
+
+    for (size_t i = 0; i < valueStr.length(); i += 2) {
+        unsigned char byte =
+            static_cast<unsigned char>(std::strtol(valueStr.substr(i, 2).c_str(), nullptr, 16));
+
+        bytePatch.push_back(byte);
+    }
+    std::memcpy(cheatAddress, bytePatch.data(), bytePatch.size());
+
+    LOG_INFO(Loader, "Applied patch:{}, Offset:{}, Value:{}", modNameStr, (uintptr_t)cheatAddress, valueStr);
+}
+
+}

--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -15,16 +15,23 @@ void ApplyPendingPatches() {
 
 	for (size_t i = 0; i < pending_patches.size(); ++i) {
         patchInfo currentPatch = pending_patches[i];
-        LOG_INFO(Loader, "loading patch {}", i);
-        PatchMemory(currentPatch.modNameStr, currentPatch.offsetStr, currentPatch.valueStr);
+        PatchMemory(currentPatch.modNameStr, currentPatch.offsetStr, currentPatch.valueStr,
+            currentPatch.isOffset);
     }
 
     pending_patches.clear();
 }
 
-void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr) {
+void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr, bool isOffset) {
     // Send a request to modify the process memory.
-    void* cheatAddress = reinterpret_cast<void*>(g_eboot_address + std::stoi(offsetStr, 0, 16));
+    void* cheatAddress = nullptr;
+
+    if (isOffset) {
+        cheatAddress = reinterpret_cast<void*>(g_eboot_address + std::stoi(offsetStr, 0, 16));
+    } else {
+        cheatAddress =
+            reinterpret_cast<void*>(g_eboot_address + (std::stoi(offsetStr, 0, 16) - 0x400000));
+    }
 
     std::vector<unsigned char> bytePatch;
 

--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -1,8 +1,7 @@
-#include "memory_patcher.h"
 #include "common/logging/log.h"
+#include "memory_patcher.h"
 
-namespace MemoryPatcher 
-{
+namespace MemoryPatcher {
 
 uintptr_t g_eboot_address;
 
@@ -25,8 +24,7 @@ void ApplyPendingPatches() {
 
 void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr) {
     // Send a request to modify the process memory.
-    void* cheatAddress =
-        reinterpret_cast<void*>(g_eboot_address + std::stoi(offsetStr, 0, 16));
+    void* cheatAddress = reinterpret_cast<void*>(g_eboot_address + std::stoi(offsetStr, 0, 16));
 
     std::vector<unsigned char> bytePatch;
 
@@ -38,7 +36,8 @@ void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valu
     }
     std::memcpy(cheatAddress, bytePatch.data(), bytePatch.size());
 
-    LOG_INFO(Loader, "Applied patch:{}, Offset:{}, Value:{}", modNameStr, (uintptr_t)cheatAddress, valueStr);
+    LOG_INFO(Loader, "Applied patch:{}, Offset:{}, Value:{}", modNameStr, (uintptr_t)cheatAddress,
+        valueStr);
 }
 
-}
+} // namespace MemoryPatcher

--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -13,7 +13,7 @@ void AddPatchToQueue(patchInfo patchToAdd) {
 
 void ApplyPendingPatches() {
 
-for (size_t i = 0; i < pending_patches.size(); ++i) {
+    for (size_t i = 0; i < pending_patches.size(); ++i) {
         patchInfo currentPatch = pending_patches[i];
         PatchMemory(currentPatch.modNameStr, currentPatch.offsetStr, currentPatch.valueStr,
                     currentPatch.isOffset);

--- a/src/common/memory_patcher.h
+++ b/src/common/memory_patcher.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <cstring>
+#include <vector>
+#include <string>
+
+namespace MemoryPatcher 
+{
+	extern uintptr_t g_eboot_address;
+
+	struct patchInfo {
+        std::string modNameStr;
+        std::string offsetStr;
+        std::string valueStr;
+	};
+
+	extern std::vector<patchInfo> pending_patches;
+
+	void AddPatchToQueue(patchInfo patchToAdd);
+	void ApplyPendingPatches();
+
+	void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr);
+
+
+}

--- a/src/common/memory_patcher.h
+++ b/src/common/memory_patcher.h
@@ -1,24 +1,23 @@
 #pragma once
 #include <cstring>
-#include <vector>
 #include <string>
+#include <vector>
 
-namespace MemoryPatcher 
-{
-	extern uintptr_t g_eboot_address;
+namespace MemoryPatcher {
 
-	struct patchInfo {
-        std::string modNameStr;
-        std::string offsetStr;
-        std::string valueStr;
-	};
+extern uintptr_t g_eboot_address;
 
-	extern std::vector<patchInfo> pending_patches;
+struct patchInfo {
+    std::string modNameStr;
+    std::string offsetStr;
+    std::string valueStr;
+};
 
-	void AddPatchToQueue(patchInfo patchToAdd);
-	void ApplyPendingPatches();
+extern std::vector<patchInfo> pending_patches;
 
-	void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr);
+void AddPatchToQueue(patchInfo patchToAdd);
+void ApplyPendingPatches();
 
+void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr);
 
-}
+} // namespace MemoryPatcher

--- a/src/common/memory_patcher.h
+++ b/src/common/memory_patcher.h
@@ -11,6 +11,7 @@ struct patchInfo {
     std::string modNameStr;
     std::string offsetStr;
     std::string valueStr;
+    bool isOffset;
 };
 
 extern std::vector<patchInfo> pending_patches;
@@ -18,6 +19,6 @@ extern std::vector<patchInfo> pending_patches;
 void AddPatchToQueue(patchInfo patchToAdd);
 void ApplyPendingPatches();
 
-void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr);
+void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr, bool isOffset);
 
 } // namespace MemoryPatcher

--- a/src/common/memory_patcher.h
+++ b/src/common/memory_patcher.h
@@ -19,6 +19,7 @@ extern std::vector<patchInfo> pending_patches;
 void AddPatchToQueue(patchInfo patchToAdd);
 void ApplyPendingPatches();
 
-void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr, bool isOffset);
+void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr,
+                 bool isOffset);
 
 } // namespace MemoryPatcher

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -5,13 +5,13 @@
 #include "common/alignment.h"
 #include "common/assert.h"
 #include "common/logging/log.h"
+#include "common/memory_patcher.h"
 #include "common/string_util.h"
 #include "core/aerolib/aerolib.h"
 #include "core/cpu_patches.h"
 #include "core/loader/dwarf.h"
 #include "core/memory.h"
 #include "core/module.h"
-#include "common/memory_patcher.h"
 
 namespace Core {
 
@@ -197,11 +197,9 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     if (MemoryPatcher::g_eboot_address == 0) {
         if (name == "eboot") {
             MemoryPatcher::g_eboot_address = base_virtual_addr;
-
             MemoryPatcher::ApplyPendingPatches();
         }
     }
-
 }
 
 void Module::LoadDynamicInfo() {

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -11,6 +11,7 @@
 #include "core/loader/dwarf.h"
 #include "core/memory.h"
 #include "core/module.h"
+#include "common/memory_patcher.h"
 
 namespace Core {
 
@@ -18,8 +19,6 @@ using EntryFunc = PS4_SYSV_ABI int (*)(size_t args, const void* argp, void* para
 
 static u64 LoadOffset = CODE_BASE_OFFSET;
 static constexpr u64 CODE_BASE_INCR = 0x010000000u;
-
-uintptr_t g_eboot_address;
 
 static u64 GetAlignedSize(const elf_program_header& phdr) {
     return (phdr.p_align != 0 ? (phdr.p_memsz + (phdr.p_align - 1)) & ~(phdr.p_align - 1)
@@ -91,12 +90,6 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
                       MemoryMapFlags::Fixed, VMAType::Code, name, true);
     LoadOffset += CODE_BASE_INCR * (1 + aligned_base_size / CODE_BASE_INCR);
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));
-
-    if (g_eboot_address == 0) {
-        if (name == "eboot") {
-            g_eboot_address = base_virtual_addr;
-        }
-    }
 
     // Initialize trampoline generator.
     void* trampoline_addr = std::bit_cast<void*>(base_virtual_addr + aligned_base_size);
@@ -200,6 +193,15 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 
     const VAddr entry_addr = base_virtual_addr + elf.GetElfEntry();
     LOG_INFO(Core_Linker, "program entry addr ..........: {:#018x}", entry_addr);
+
+    if (MemoryPatcher::g_eboot_address == 0) {
+        if (name == "eboot") {
+            MemoryPatcher::g_eboot_address = base_virtual_addr;
+
+            MemoryPatcher::ApplyPendingPatches();
+        }
+    }
+
 }
 
 void Module::LoadDynamicInfo() {

--- a/src/core/module.h
+++ b/src/core/module.h
@@ -243,6 +243,4 @@ public:
     std::vector<u8> rela_bits;
 };
 
-extern uintptr_t g_eboot_address;
-
 } // namespace Core

--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -26,9 +26,9 @@
 #include <QXmlStreamReader>
 #include <common/logging/log.h>
 #include "cheats_patches.h"
+#include "common/memory_patcher.h"
 #include "common/path_util.h"
 #include "core/module.h"
-#include "common/memory_patcher.h"
 
 using namespace Common::FS;
 

--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -663,7 +663,7 @@ void CheatsPatches::applyPatch(const QString& patchName, bool enabled) {
             QString address = lineObject["Address"].toString();
             QString patchValue = lineObject["Value"].toString();
 
-             if (MemoryPatcher::g_eboot_address == 0) {
+            if (MemoryPatcher::g_eboot_address == 0) {
                 MemoryPatcher::patchInfo addingPatch;
                 addingPatch.modNameStr = patchName.toStdString();
                 addingPatch.offsetStr = address.toStdString();

--- a/src/qt_gui/cheats_patches.h
+++ b/src/qt_gui/cheats_patches.h
@@ -50,6 +50,7 @@ private:
     void createFilesJson();
     void uncheckAllCheatCheckBoxes();
     void applyCheat(const QString& modName, bool enabled);
+    void applyPatch(const QString& patchName, bool enabled);
 
     // Event Filtering
     bool eventFilter(QObject* obj, QEvent* event);


### PR DESCRIPTION
Moved memory patching functions to a seperate file so it can be called from both module.cpp when the game is started and also the GUI at runtime, cheats can now be enabled before the game is started and basic 'byte' type patches work. 

I still need to implement the rest of the types, and pattern scanning, but i wanted to push this so you can test