### PR TITLE
fix issues with byte16, byte32, byte64 type patches

### DIFF
--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "common/logging/log.h"
 #include <algorithm>
 #include <string>
+#include "common/logging/log.h"
 #include "memory_patcher.h"
 
 namespace MemoryPatcher {
@@ -27,8 +27,8 @@ void ApplyPendingPatches() {
     pending_patches.clear();
 }
 
-void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr,
-                 bool isOffset, bool littleEndian) {
+void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr, bool isOffset,
+                 bool littleEndian) {
     // Send a request to modify the process memory.
     void* cheatAddress = nullptr;
 

--- a/src/common/memory_patcher.h
+++ b/src/common/memory_patcher.h
@@ -15,6 +15,7 @@ struct patchInfo {
     std::string offsetStr;
     std::string valueStr;
     bool isOffset;
+    bool littleEndian;
 };
 
 extern std::vector<patchInfo> pending_patches;
@@ -23,6 +24,6 @@ void AddPatchToQueue(patchInfo patchToAdd);
 void ApplyPendingPatches();
 
 void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr,
-                 bool isOffset);
+                 bool isOffset, bool littleEndian);
 
 } // namespace MemoryPatcher

--- a/src/common/memory_patcher.h
+++ b/src/common/memory_patcher.h
@@ -23,7 +23,7 @@ extern std::vector<patchInfo> pending_patches;
 void AddPatchToQueue(patchInfo patchToAdd);
 void ApplyPendingPatches();
 
-void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr,
-                 bool isOffset, bool littleEndian);
+void PatchMemory(std::string modNameStr, std::string offsetStr, std::string valueStr, bool isOffset,
+                 bool littleEndian);
 
 } // namespace MemoryPatcher

--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -860,7 +860,7 @@ void CheatsPatches::applyCheat(const QString& modName, bool enabled) {
             continue;
         }
 
-        MemoryPatcher::PatchMemory(modNameStr, offsetStr, valueStr, true);
+        MemoryPatcher::PatchMemory(modNameStr, offsetStr, valueStr, true, false);
     }
 }
 
@@ -876,19 +876,30 @@ void CheatsPatches::applyPatch(const QString& patchName, bool enabled) {
 
             patchValue = convertValueToHex(type, patchValue);
 
+            bool littleEndian = false;
+
+            if (type.toStdString() == "bytes16") {
+                littleEndian = true;
+            } else if (type.toStdString() == "bytes32") {
+                littleEndian = true;
+            } else if (type.toStdString() == "bytes64") {
+                littleEndian = true;
+            }
+
             if (MemoryPatcher::g_eboot_address == 0) {
                 MemoryPatcher::patchInfo addingPatch;
                 addingPatch.modNameStr = patchName.toStdString();
                 addingPatch.offsetStr = address.toStdString();
                 addingPatch.valueStr = patchValue.toStdString();
                 addingPatch.isOffset = false;
+                addingPatch.littleEndian = littleEndian;
 
                 MemoryPatcher::AddPatchToQueue(addingPatch);
                 continue;
             }
 
             MemoryPatcher::PatchMemory(patchName.toStdString(), address.toStdString(),
-                                       patchValue.toStdString(), false);
+                                       patchValue.toStdString(), false, littleEndian);
         }
     }
 }


### PR DESCRIPTION
If a patch is any of these types we convert it from little endian to big endian